### PR TITLE
[10.x] Fix DB `Cache::add()` error in Postgres within transaction

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Cache\Store;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\InteractsWithTime;
 use Illuminate\Support\Str;
 
@@ -157,7 +158,8 @@ class DatabaseStore implements LockProvider, Store
             return false;
         }
 
-        if (method_exists($this->table(), 'insertOrIgnore')) {
+        $notSupportInsertOrIgnoreConnections = [SqlServerConnection::class];
+        if (! in_array(get_class($this->getConnection()), $notSupportInsertOrIgnoreConnections)) {
             return $this->table()->insertOrIgnore(compact('key', 'value', 'expiration')) > 0;
         }
 

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -153,17 +153,20 @@ class DatabaseStore implements LockProvider, Store
         $value = $this->serialize($value);
         $expiration = $this->getTime() + $seconds;
 
+        if ($this->get($key) !== null) {
+            return false;
+        }
+
+        if (method_exists($this->table(), 'insertOrIgnore')) {
+            return $this->table()->insertOrIgnore(compact('key', 'value', 'expiration')) > 0;
+        }
+
         try {
             return $this->table()->insert(compact('key', 'value', 'expiration'));
         } catch (QueryException) {
-            return $this->table()
-                ->where('key', $key)
-                ->where('expiration', '<=', $this->getTime())
-                ->update([
-                    'value' => $value,
-                    'expiration' => $expiration,
-                ]) >= 1;
+            // ignore if duplicate
         }
+        return false;
     }
 
     /**

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -41,6 +41,66 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('new-bar', $store->get('foo'));
     }
 
+    public function testAddOperationCanStoreNewCache()
+    {
+        $store = $this->getStore();
+
+        $result = $store->add('foo', 'bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCache()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCacheInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpired()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpiredInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
     protected function getStore()
     {
         return Cache::store('database');


### PR DESCRIPTION
## Problem


2. Postgres error, see [previous mr here](url), and i also make a integration test to prove this bug [here](url)