### PR TITLE
Prove it has bug when PG cache store `add()` on exist cache

### DIFF
--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -41,6 +41,66 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('new-bar', $store->get('foo'));
     }
 
+    public function testAddOperationCanStoreNewCache()
+    {
+        $store = $this->getStore();
+
+        $result = $store->add('foo', 'bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCache()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotUpdateExistCacheInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 60);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertFalse($result);
+        $this->assertSame('bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpired()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+        $result = $store->add('foo', 'new-bar', 60);
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
+    public function testAddOperationCanUpdateIfCacheExpiredInTransaction()
+    {
+        $store = $this->getStore();
+
+        $store->add('foo', 'bar', 0);
+
+        DB::beginTransaction();
+        $result = $store->add('foo', 'new-bar', 60);
+        DB::commit();
+
+        $this->assertTrue($result);
+        $this->assertSame('new-bar', $store->get('foo'));
+    }
+
     protected function getStore()
     {
         return Cache::store('database');


### PR DESCRIPTION
<!--
Please only send a pull request to branches that are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
