### PR TITLE
[10.x] Prevent Cache::get() occur race condition

### DIFF
--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -115,7 +115,7 @@ class DatabaseStore implements LockProvider, Store
         // item from the cache. Then we will return a null value since the cache is
         // expired. We will use "Carbon" to make this comparison with the column.
         if ($this->currentTime() >= $cache->expiration) {
-            $this->forget($key);
+            $this->forgetIfExpired($key);
 
             return;
         }
@@ -312,6 +312,22 @@ class DatabaseStore implements LockProvider, Store
     public function forget($key)
     {
         $this->table()->where('key', '=', $this->prefix.$key)->delete();
+
+        return true;
+    }
+
+    /**
+     * Remove an item from the cache if expired.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    public function forgetIfExpired($key)
+    {
+        $this->table()
+            ->where('key', '=', $this->prefix.$key)
+            ->where('expiration', '<=', $this->getTime())
+            ->delete();
 
         return true;
     }

--- a/src/Illuminate/Cache/DatabaseStore.php
+++ b/src/Illuminate/Cache/DatabaseStore.php
@@ -150,11 +150,12 @@ class DatabaseStore implements LockProvider, Store
      */
     public function add($key, $value, $seconds)
     {
+        $noPrefixKey = $key;
         $key = $this->prefix.$key;
         $value = $this->serialize($value);
         $expiration = $this->getTime() + $seconds;
 
-        if (! is_null($this->get($key))) {
+        if (! is_null($this->get($noPrefixKey))) {
             return false;
         }
 

--- a/tests/Cache/CacheDatabaseStoreTest.php
+++ b/tests/Cache/CacheDatabaseStoreTest.php
@@ -30,12 +30,12 @@ class CacheDatabaseStoreTest extends TestCase
 
     public function testNullIsReturnedAndItemDeletedWhenItemIsExpired()
     {
-        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forget'])->setConstructorArgs($this->getMocks())->getMock();
+        $store = $this->getMockBuilder(DatabaseStore::class)->onlyMethods(['forgetIfExpired'])->setConstructorArgs($this->getMocks())->getMock();
         $table = m::mock(stdClass::class);
         $store->getConnection()->shouldReceive('table')->once()->with('table')->andReturn($table);
         $table->shouldReceive('where')->once()->with('key', '=', 'prefixfoo')->andReturn($table);
         $table->shouldReceive('first')->once()->andReturn((object) ['expiration' => 1]);
-        $store->expects($this->once())->method('forget')->with($this->equalTo('foo'))->willReturn(null);
+        $store->expects($this->once())->method('forgetIfExpired')->with($this->equalTo('foo'))->willReturn(null);
 
         $this->assertNull($store->get('foo'));
     }

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -25,7 +25,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $result = $store->put('foo', 'bar', -1);
 
         $this->assertTrue($result);
-        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->$this->withCachePrefix('foo'), 'value' => 'bar']);
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo'), 'value' => 'bar']);
     }
 
     public function testValueCanUpdateExistCache()

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -18,6 +18,16 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
+    public function testPutOperationCanStoreExpired()
+    {
+        $store = $this->getStore();
+
+        $result = $store->put('foo', 'bar', -1);
+
+        $this->assertTrue($result);
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => 'foo', 'value' => 'bar']);
+    }
+
     public function testValueCanUpdateExistCache()
     {
         $store = $this->getStore();
@@ -39,6 +49,16 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         DB::commit();
 
         $this->assertSame('new-bar', $store->get('foo'));
+    }
+
+    public function testAddOperationShouldNotStoreExpired()
+    {
+        $store = $this->getStore();
+
+        $result = $store->add('foo', 'bar', -1);
+
+        $this->assertFalse($result);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => 'foo', 'value' => 'bar']);
     }
 
     public function testAddOperationCanStoreNewCache()
@@ -80,7 +100,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->add('foo', 'bar', 0);
+        $store->put('foo', 'bar', -1);
         $result = $store->add('foo', 'new-bar', 60);
 
         $this->assertTrue($result);
@@ -91,7 +111,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->add('foo', 'bar', 0);
+        $store->put('foo', 'bar', -1);
 
         DB::beginTransaction();
         $result = $store->add('foo', 'new-bar', 60);

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -25,7 +25,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $result = $store->put('foo', 'bar', -1);
 
         $this->assertTrue($result);
-        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => 'foo', 'value' => 'bar']);
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->$this->withCachePrefix('foo'), 'value' => 'bar']);
     }
 
     public function testValueCanUpdateExistCache()
@@ -58,7 +58,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $result = $store->add('foo', 'bar', -1);
 
         $this->assertFalse($result);
-        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => 'foo', 'value' => 'bar']);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo'), 'value' => 'bar']);
     }
 
     public function testAddOperationCanStoreNewCache()
@@ -140,7 +140,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
 
         $store->get('foo');
 
-        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => 'foo']);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
     }
 
     public function testForgetIfExpiredOperationCanDeleteExpired()
@@ -151,7 +151,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
 
         $store->forgetIfExpired('foo');
 
-        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => 'foo']);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
     }
 
     public function testForgetIfExpiredOperationShouldNotDeleteUnExpired()
@@ -162,7 +162,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
 
         $store->forgetIfExpired('foo');
 
-        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => 'foo']);
+        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo')]);
     }
 
     /**
@@ -176,5 +176,10 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     protected function getCacheTableName()
     {
         return config('cache.stores.database.table');
+    }
+
+    protected function withCachePrefix(string $key)
+    {
+        return config('cache.prefix').$key;
     }
 }

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -190,7 +190,7 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
                 [
                     'key' => $this->withCachePrefix($key),
                     'value' => $value,
-                    'expiration' => Carbon::now()->addSeconds($ttl)->getTimestamp()
+                    'expiration' => Carbon::now()->addSeconds($ttl)->getTimestamp(),
                 ]
             );
     }

--- a/tests/Integration/Database/DatabaseCacheStoreTest.php
+++ b/tests/Integration/Database/DatabaseCacheStoreTest.php
@@ -18,14 +18,14 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
         $this->assertSame('bar', $store->get('foo'));
     }
 
-    public function testPutOperationCanStoreExpired()
+    public function testPutOperationShouldNotStoreExpired()
     {
         $store = $this->getStore();
 
         $result = $store->put('foo', 'bar', -1);
 
-        $this->assertTrue($result);
-        $this->assertDatabaseHas($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo'), 'value' => 'bar']);
+        $this->assertFalse($result);
+        $this->assertDatabaseMissing($this->getCacheTableName(), ['key' => $this->withCachePrefix('foo'), 'value' => 'bar']);
     }
 
     public function testValueCanUpdateExistCache()
@@ -100,7 +100,13 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->put('foo', 'bar', -1);
+        $this->insertToCacheTable(
+            [
+                'key' => $this->withCachePrefix('foo'),
+                'value' => 'bar',
+                'expiration' => 0
+            ]
+        );
         $result = $store->add('foo', 'new-bar', 60);
 
         $this->assertTrue($result);
@@ -111,7 +117,13 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->put('foo', 'bar', -1);
+        $this->insertToCacheTable(
+            [
+                'key' => $this->withCachePrefix('foo'),
+                'value' => 'bar',
+                'expiration' => 0
+            ]
+        );
 
         DB::beginTransaction();
         $result = $store->add('foo', 'new-bar', 60);
@@ -125,7 +137,13 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->put('foo', 'bar', -1);
+        $this->insertToCacheTable(
+            [
+                'key' => $this->withCachePrefix('foo'),
+                'value' => 'bar',
+                'expiration' => 0
+            ]
+        );
 
         $result = $store->get('foo');
 
@@ -136,7 +154,13 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->put('foo', 'bar', -1);
+        $this->insertToCacheTable(
+            [
+                'key' => $this->withCachePrefix('foo'),
+                'value' => 'bar',
+                'expiration' => 0
+            ]
+        );
 
         $store->get('foo');
 
@@ -147,7 +171,13 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     {
         $store = $this->getStore();
 
-        $store->put('foo', 'bar', -1);
+        $this->insertToCacheTable(
+            [
+                'key' => $this->withCachePrefix('foo'),
+                'value' => 'bar',
+                'expiration' => 0
+            ]
+        );
 
         $store->forgetIfExpired('foo');
 
@@ -181,5 +211,10 @@ class DatabaseCacheStoreTest extends DatabaseTestCase
     protected function withCachePrefix(string $key)
     {
         return config('cache.prefix').$key;
+    }
+
+    protected function insertToCacheTable(array $data)
+    {
+        DB::table($this->getCacheTableName())->insert($data);
     }
 }


### PR DESCRIPTION
## Problem
Database `Cache::get()` delete expired cache record automatically, but the current implementation may occur race condition, for example:

imagine there're two process run parallell
- pA: exec `Cache::get()`
- pB: exec `Cache:put()`

if **pA** get a expired cache from DB then **pB** `put()` a new cache to DB, when **pA** execute `forget()` it will delete the new cache from **pB**.

## Solution
call `forgetIfExpired()` instead of `forget()` in `Cache::get()`